### PR TITLE
Only add the formatter in Crystal mode

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -36,7 +36,8 @@
     :defer t
     :config
     (progn
-      (add-hook 'before-save-hook 'crystal-tool-format)
+      (add-hook 'crystal-mode-hook
+                (lambda () (add-hook 'before-save-hook 'crystal-tool-format nil 'local)))
 
       (defun spacemacs/crystal-run-main ()
         (interactive)


### PR DESCRIPTION
I found that the formatter would also run on my Ruby code, and discovered that it seemed to actually be active in all major modes, and just would appear not to do anything because most non-Crystal files wouldn't parse correctly, and thus wouldn't get reformatted.

This change will make it so that the tool formatter is only hooked up when in `crystal-mode`.